### PR TITLE
Add refresh password and permanent token

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const routes = require('./routes');
-const database = require('./database/index');
+
+require('./database/index');
 
 class App {
   constructor() {

--- a/src/app/models/User.js
+++ b/src/app/models/User.js
@@ -7,14 +7,14 @@ class User extends Model {
     super.init(
       {
         name: {
-         type: Sequelize.STRING,
-         allowNull: false,
-         validate: {
-           notEmpty: true,
-           notNull: true,
-         },
-        },  
-        email: { 
+          type: Sequelize.STRING,
+          allowNull: false,
+          validate: {
+            notEmpty: true,
+            notNull: true,
+          },
+        },
+        email: {
           type: Sequelize.STRING,
           allowNull: false,
           validate: {
@@ -29,7 +29,7 @@ class User extends Model {
             notEmpty: true,
             notNull: true,
           },
-        },  
+        },
         password_hash: Sequelize.STRING,
       },
       {

--- a/src/routes.js
+++ b/src/routes.js
@@ -13,7 +13,6 @@ const routes = new Router();
 routes.use('/api-docs', swaggerUi.serve);
 routes.use('/api-docs', swaggerUi.setup(swaggerDoc));
 
-routes.post('/login', UserController.login);
 routes.post('/users', UserController.store);
 routes.post('/session', SessionController.store);
 
@@ -21,7 +20,7 @@ routes.post('/session', SessionController.store);
 routes.use(authMiddleware);
 
 routes.get('/users/:id', UserController.show);
-routes.put('/users/:id', UserController.update);
+routes.put('/users', UserController.update);
 routes.delete('/users/:id', UserController.delete);
 
 routes.post('/logs', LogController.saveLog);


### PR DESCRIPTION
So, I removed added a refresh password feature, now the logged user is able to refresh his password only passing his email, oldPassword and the new one. 
In the user creation moment, now is generated a permanent token to this API be able to use "as a service", and also we have the session, so it continues with the login/logout feature.